### PR TITLE
Desktop compat hack

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -4,7 +4,7 @@ import readingTime from "reading-time";
 
 import { MuiThemeProvider } from "@material-ui/core/styles";
 
-import { CssBaseline, Button, Snackbar } from "@material-ui/core";
+import { CssBaseline, Grid, Button, Snackbar } from "@material-ui/core";
 
 import { auth, firestore } from "../../firebase";
 import authentication from "../../services/authentication";
@@ -270,7 +270,11 @@ class App extends Component {
 
           {ready && (
             <>
-              <Router user={user} />
+              <Grid container alignItems="center" justify="center" style={{ height: "100vh" }}>
+                <Grid item style={{ position: "relative", width: "100%", height: "100%", maxWidth: theme.breakpoints.values.sm, maxHeight: 900 }}>
+                  <Router user={user} />
+                </Grid>
+              </Grid>
 
               <DialogHost
                 performingAction={performingAction}

--- a/src/components/HomeLayout/HomeLayout.js
+++ b/src/components/HomeLayout/HomeLayout.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import Container from "@material-ui/core/Container";
+import Box from "@material-ui/core/Box";
 import Toolbar from '@material-ui/core/Toolbar';
 import Grid from "@material-ui/core/Grid";
 import MenuIcon from "@material-ui/icons/Menu";
@@ -11,7 +11,7 @@ const useStyles = makeStyles({
   container: {
     position: "relative",
     minWidth: "375px",
-    height: "100vh",
+    height: "100%",
     padding: 0,
     backgroundSize: "cover",
     backgroundRepeat: "no-repeat",
@@ -32,7 +32,7 @@ const OnBoardingLayout = ({ children, bg, activeStep }) => {
   const bgUrl = bg[activeStep] ? bg[activeStep] : bg[bg.length - 1]
 
   return (
-    <Container maxWidth="lg" className={classes.container} style={{ backgroundImage: `url(${ bgUrl })`}}>
+    <Box className={classes.container} style={{ backgroundImage: `url(${ bgUrl })`}}>
       <Grid container>
         <Grid container direction="column">
           <Toolbar className={classes.toolbar}>
@@ -42,7 +42,7 @@ const OnBoardingLayout = ({ children, bg, activeStep }) => {
         </Grid>
         {children[activeStep]}
       </Grid>
-    </Container>
+    </Box>
   );
 }
 

--- a/src/components/OnBoardingLayout/OnBoardingLayout.js
+++ b/src/components/OnBoardingLayout/OnBoardingLayout.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { makeStyles } from "@material-ui/core/styles";
-import Container from "@material-ui/core/Container";
+import Box from "@material-ui/core/Box";
 import Toolbar from '@material-ui/core/Toolbar';
 import Grid from "@material-ui/core/Grid";
 import MobileStepper from "@material-ui/core/MobileStepper";
@@ -15,7 +15,7 @@ const useStyles = makeStyles({
   container: {
     position: "relative",
     minWidth: "375px",
-    height: "100vh",
+    height: "100%",
     padding: 0,
     backgroundSize: "cover",
     backgroundRepeat: "no-repeat",
@@ -66,7 +66,7 @@ const OnBoardingLayout = ({ children, bg, endOnBoarding }) => {
   }
 
   return (
-    <Container maxWidth="lg" className={classes.container} style={{ backgroundImage: `url(${ bg[activeStep] })`}}>
+    <Box className={classes.container} style={{ backgroundImage: `url(${ bg[activeStep] })`}}>
       <Grid container>
         <Grid container direction="column">
           <Toolbar className={classes.toolbar}>
@@ -99,7 +99,7 @@ const OnBoardingLayout = ({ children, bg, endOnBoarding }) => {
           </Grid>
         </Grid>
       </Grid>
-    </Container>
+    </Box>
   );
 }
 

--- a/src/pages/Admin/Layout/Layout.js
+++ b/src/pages/Admin/Layout/Layout.js
@@ -16,6 +16,9 @@ function Layout({ children, bg, hideToolbar }) {
     height: 1,
     style: {
       background: `url(${bg})`,
+      backgroundSize: 'cover',
+      backgroundPosition: '0 100%',
+      backgroundRepeat: 'no-repeat',
       textAlign: 'center'
     }
   }


### PR DESCRIPTION
Foi discutido a questão do site ser apenas mobile durante última reunião que tive, o que levanta algumas questões para os lojistas visto que talvez a utilização mais provável será um PC e ñ tanto um dispositivo mobile.
Visto que o site ñ fica nada bom actualmente em grandes dimensões, é limitado o tamanho do container até um certo ponto e depois fica centrado no ecrã.
Eu sei que ñ é a melhor solução mas visto ainda ñ termos o design pra outros tamanhos e tb visto que pretendo sermos mais focados nos flows do que nestas situações pontuais pra MVP, é o melhor q se arranja.

De qualquer modo o design desktop virá logo a seguir a termos terminado os flows.