### PR TITLE
fix: max-length for store name

### DIFF
--- a/src/pages/Admin/SignUp/SignUp.js
+++ b/src/pages/Admin/SignUp/SignUp.js
@@ -126,7 +126,7 @@ function SignUp({ openSnackbar }) {
           name="defaultQueueName"
           onChange={e => handleChange(e)}
           helperText="ex: PDoceCartaxo"
-          inputProps={{ maxLength: 20 }}
+          inputProps={{ maxLength: 30 }}
           {...inputProps}
         />
 


### PR DESCRIPTION
### What does it do?

- Fixes https://trello.com/c/R5eOwKT2/45-nome-de-loja-com-carateres-limitados. Max length is now 30 chars