### PR TITLE
[RFC][243] Hide ended queues from public status screen

### DIFF
--- a/src/pages/QueueStatus/Components/Queues.js
+++ b/src/pages/QueueStatus/Components/Queues.js
@@ -158,7 +158,7 @@ const handleClassUpdate = (queueId, updatedQueue, setUpdatedQueue) => {
     setUpdatedQueue("");
   }, 650);
   // eslint-disable-next-line
-    return updatedQueue == queueId ? "circle circle-blink" : "circle";
+  return updatedQueue === queueId ? "circle circle-blink" : "circle";
 };
 
 const getChunks = (arr, chunkSize) => {
@@ -238,8 +238,10 @@ export const Queues = ({ isDesktop }) => {
     const userParams = urlParams.get("users");
     const users = userParams.split(",");
     const chunks = getChunks(users, 10);
+    const firebaseUnsubscribeFns = [];
+
     chunks.forEach((c, i) => {
-      firestore
+      const unsubscribe = firestore
         .collection("queues")
         .where("owner_id", "in", c)
         .onSnapshot(snapshot => {
@@ -266,7 +268,11 @@ export const Queues = ({ isDesktop }) => {
 
           setQueuesData([...queuesData, ...queues]);
         });
+
+      firebaseUnsubscribeFns.push(unsubscribe);
     });
+
+    return () => firebaseUnsubscribeFns.forEach(fn => fn());
   }, [queuesData]);
 
   new Swiper(".swiper-container", {

--- a/src/pages/QueueStatus/Components/Queues.js
+++ b/src/pages/QueueStatus/Components/Queues.js
@@ -168,107 +168,97 @@ const getChunks = (arr, chunkSize) => {
   return c;
 };
 
-const renderQueues = (
-  isDesktop,
-  requestQueues,
-  queuesData,
-  updatedQueue,
-  setUpdatedQueue
-) => {
-  if (requestQueues) {
-    if (Object.keys(queuesData).length === 1) {
-      const queueKey = Object.keys(queuesData)[0];
-      return (
-        <>
-          <BigCircle>
-            <div
-              className={handleClassUpdate(
-                queuesData[queueKey].owner_id,
-                updatedQueue,
-                setUpdatedQueue
-              )}
-            >
-              <p>{queuesData[queueKey].currentTicketNumber}</p>
-            </div>
-          </BigCircle>
-          <BigLabel>
-            <p>{queuesData[queueKey].name}</p>
-          </BigLabel>
-        </>
-      );
-    } else if (Object.keys(queuesData).length) {
-      const chuncksSize = isDesktop ? 12 : 8;
-      const chunks = getChunks(Object.keys(queuesData), chuncksSize);
-      return (
-        <div class="swiper-container">
-          <div class="swiper-wrapper">
-            {chunks.map(c => (
-              <div class="swiper-slide">
-                <GridArea isDesktop={isDesktop}>
-                  {c.map(key => (
-                    <QueueWrapper isDesktop={isDesktop}>
-                      <div
-                        className={handleClassUpdate(
-                          queuesData[key].owner_id,
-                          updatedQueue,
-                          setUpdatedQueue
-                        )}
-                      >
-                        <p>{queuesData[key].currentTicketNumber}</p>
-                      </div>
-                      <div className="name">
-                        <p>{queuesData[key].name}</p>
-                      </div>
-                    </QueueWrapper>
-                  ))}
-                </GridArea>
-              </div>
-            ))}
-          </div>
-          <div class="swiper-pagination"></div>
-        </div>
-      );
-    }
+const renderQueues = (isDesktop, queuesData, updatedQueue, setUpdatedQueue) => {
+  if (!queuesData.length) {
+    return <></>;
   }
+
+  if (queuesData.length === 1) {
+    const [{ owner_id, currentTicketNumber, name }] = queuesData;
+
+    return (
+      <>
+        <BigCircle>
+          <div
+            className={handleClassUpdate(
+              owner_id,
+              updatedQueue,
+              setUpdatedQueue
+            )}
+          >
+            <p>{currentTicketNumber}</p>
+          </div>
+        </BigCircle>
+        <BigLabel>
+          <p>{name}</p>
+        </BigLabel>
+      </>
+    );
+  }
+
+  const chunksSize = isDesktop ? 12 : 8;
+  const chunks = getChunks(queuesData, chunksSize);
+
+  return (
+    <div className="swiper-container">
+      <div className="swiper-wrapper">
+        <div className="swiper-slide">
+          <GridArea isDesktop={isDesktop}>
+            {queuesData.map(({ id, owner_id, currentTicketNumber, name }) => (
+              <QueueWrapper key={id} isDesktop={isDesktop}>
+                <div
+                  className={handleClassUpdate(
+                    owner_id,
+                    updatedQueue,
+                    setUpdatedQueue
+                  )}
+                >
+                  <p>{currentTicketNumber}</p>
+                </div>
+                <div className="name">
+                  <p>{name}</p>
+                </div>
+              </QueueWrapper>
+            ))}
+          </GridArea>
+        </div>
+      </div>
+      <div className="swiper-pagination"></div>
+    </div>
+  );
 };
 
 export const Queues = ({ isDesktop }) => {
   const [updatedQueue, setUpdatedQueue] = useState("");
-  const [queuesData, setQueuesData] = useState({});
-  const [requestQueues, setRequest] = useState(false);
+  const [queuesData, setQueuesData] = useState([]);
 
   useEffect(() => {
-    if (!requestQueues) {
-      setUpdatedQueue("");
-      const urlParams = new URLSearchParams(window.location.search);
-      const userParams = urlParams.get("users");
-      if (!userParams) return null;
-      const users = userParams.split(",");
-      const chunks = getChunks(users, 10);
-      chunks.forEach((c, i) => {
-        firestore
-          .collection("queues")
-          .where("owner_id", "in", c)
-          .onSnapshot(snapshot => {
-            let queueDocs = snapshot.docs;
-            queueDocs.forEach(qd => {
-              queuesData[qd.ref.id] = qd.data();
-            });
-            // const updated
-            const queuesClone = Object.assign({}, queuesData);
-            setQueuesData(queuesClone);
-            if (i === chunks.length - 1) setRequest(true);
+    setUpdatedQueue("");
+    const urlParams = new URLSearchParams(window.location.search);
+    const userParams = urlParams.get("users");
+    const users = userParams.split(",");
+    const chunks = getChunks(users, 10);
+    chunks.forEach((c, i) => {
+      firestore
+        .collection("queues")
+        .where("owner_id", "in", c)
+        .onSnapshot(snapshot => {
+          const queues = snapshot.docs.map(ref => {
+            const data = ref.data();
 
-            //Check for updates
-            snapshot.docChanges().forEach(function (change) {
-              if (change.type === "modified") {
-                setUpdatedQueue(change.doc.data().owner_id);
-              }
-            });
+            return { id: ref.id, ...data };
           });
-      });
-    }
-  }, [queuesData, requestQueues]);
+
+          setQueuesData([...queuesData, ...queues]);
+
+          snapshot.docChanges().forEach(function (change) {
+            if (change.type === "modified") {
+              setUpdatedQueue(change.doc.data().owner_id);
+            }
+          });
+        });
+    });
+  }, [queuesData]);
 
   new Swiper(".swiper-container", {
     slidesPerView: 1,
@@ -284,13 +274,7 @@ export const Queues = ({ isDesktop }) => {
 
   return (
     <QueuesWrapper isDesktop={isDesktop}>
-      {renderQueues(
-        isDesktop,
-        requestQueues,
-        queuesData,
-        updatedQueue,
-        setUpdatedQueue
-      )}
+      {renderQueues(isDesktop, queuesData, updatedQueue, setUpdatedQueue)}
     </QueuesWrapper>
   );
 };

--- a/src/pages/QueueStatus/Components/Queues.js
+++ b/src/pages/QueueStatus/Components/Queues.js
@@ -249,13 +249,22 @@ export const Queues = ({ isDesktop }) => {
             return { id: ref.id, ...data };
           });
 
-          setQueuesData([...queuesData, ...queues]);
+          const removedQueuesIds = [];
+          snapshot.docChanges().forEach(({ type, doc }) => {
+            if (type === "modified") {
+              setUpdatedQueue(doc.data().owner_id);
+            }
 
-          snapshot.docChanges().forEach(function (change) {
-            if (change.type === "modified") {
-              setUpdatedQueue(change.doc.data().owner_id);
+            if (type === "removed") {
+              removedQueuesIds.push(doc.id);
             }
           });
+
+          const newQueues = removedQueuesIds.length
+            ? queues.filter(({ id }) => !removedQueuesIds.includes(id))
+            : queues;
+
+          setQueuesData([...queuesData, ...queues]);
         });
     });
   }, [queuesData]);


### PR DESCRIPTION
- Refactored the queues's query part and suddenly the ended queues started disappearing from the view (simplified a bit by changing the data structure from object to array)
- Improvement by removing the firebase listeners on `useEffect` cleanup;